### PR TITLE
Add vLLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,13 @@ Alternative, less restrictive, but slower backend is [whisper-timestamped](https
 
 Thirdly, it's also possible to run this software from the [OpenAI Whisper API](https://platform.openai.com/docs/api-reference/audio/createTranscription). This solution is fast and requires no GPU, just a small VM will suffice, but you will need to pay OpenAI for api access. Also note that, since each audio fragment is processed multiple times, the [price](https://openai.com/pricing) will be higher than obvious from the pricing page, so keep an eye on costs while using. Setting a higher chunk-size will reduce costs significantly. 
 Install with: `pip install openai` , [requires Python >=3.8](https://pypi.org/project/openai/).
-For running with the openai-api backend, make sure that your [OpenAI api key](https://platform.openai.com/api-keys) is set in the `OPENAI_API_KEY` environment variable. For example, before running, do: `export OPENAI_API_KEY=sk-xxx` with *sk-xxx* replaced with your api key. 
+For running with the openai-api backend, make sure that your [OpenAI api key](https://platform.openai.com/api-keys) is set in the `OPENAI_API_KEY` environment variable. For example, before running, do: `export OPENAI_API_KEY=sk-xxx` with *sk-xxx* replaced with your api key.
+
+For running with the vllm backend, set `VLLM_BASE_URL` to your vLLM server endpoint and optionally `VLLM_API_KEY` if authentication is needed.
 
 Fourthly, another efficient backend is the [Whisper MLX](https://github.com/ml-explore/mlx-examples/tree/main/whisper)  library, optimized specifically for Apple Silicon. Whisper MLX leverages the performance capabilities of Apple chips (M1, M2...) to deliver faster transcription without requiring a GPU: `pip install mlx-whisper`. All the main whisper models have been converted to the MLX format, and are listed on [Hugging Face Whisper mlx](https://huggingface.co/collections/mlx-community/whisper-663256f9964fbb1177db93dc).
+
+Fifthly, you can use a model served by [vLLM](https://github.com/vllm-project/vllm) via an OpenAI-compatible endpoint. Set the environment variables `VLLM_BASE_URL` and optionally `VLLM_API_KEY` to point to your server and install `openai`.
 
 
 The backend is loaded only when chosen. The unused one does not have to be installed.
@@ -84,7 +88,7 @@ In case of installation issues of opus-fast-mosestokenizer, especially on Window
 ```
 whisper_online.py -h
 usage: whisper_online.py [-h] [--min-chunk-size MIN_CHUNK_SIZE] [--model {tiny.en,tiny,base.en,base,small.en,small,medium.en,medium,large-v1,large-v2,large-v3,large}] [--model_cache_dir MODEL_CACHE_DIR]
-                         [--model_dir MODEL_DIR] [--lan LAN] [--task {transcribe,translate}] [--backend {faster-whisper,whisper_timestamped,openai-api}] [--vac] [--vac-chunk-size VAC_CHUNK_SIZE] [--vad]
+                         [--model_dir MODEL_DIR] [--lan LAN] [--task {transcribe,translate}] [--backend {faster-whisper,whisper_timestamped,openai-api,vllm}] [--vac] [--vac-chunk-size VAC_CHUNK_SIZE] [--vad]
                          [--buffer_trimming {sentence,segment}] [--buffer_trimming_sec BUFFER_TRIMMING_SEC] [-l {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--start_at START_AT] [--offline] [--comp_unaware]
                          audio_path
 
@@ -106,7 +110,7 @@ options:
                         Source language code, e.g. en,de,cs, or 'auto' for language detection.
   --task {transcribe,translate}
                         Transcribe or translate.
-  --backend {faster-whisper,whisper_timestamped,openai-api}
+  --backend {faster-whisper,whisper_timestamped,openai-api,vllm}
                         Load only this backend for Whisper processing.
   --vac                 Use VAC = voice activity controller. Recommended. Requires torch.
   --vac-chunk-size VAC_CHUNK_SIZE
@@ -246,6 +250,15 @@ overlap, and we limit the processing buffer window.
 ### Performance evaluation
 
 [See the paper.](http://www.afnlp.org/conferences/ijcnlp2023/proceedings/main-demo/cdrom/pdf/2023.ijcnlp-demo.3.pdf)
+
+### Benchmark script
+
+Use `benchmark_vllm_vs_fasterwhisper.py` to compare the offline transcription speed of the local FasterWhisper backend with a vLLM-served model.
+Example:
+
+```bash
+python benchmark_vllm_vs_fasterwhisper.py sample.wav --runs 5
+```
 
 ### Contributions
 

--- a/benchmark_vllm_vs_fasterwhisper.py
+++ b/benchmark_vllm_vs_fasterwhisper.py
@@ -1,0 +1,32 @@
+import time
+import argparse
+import os
+from whisper_online import FasterWhisperASR, VllmASR, load_audio
+
+parser = argparse.ArgumentParser(description="Benchmark FasterWhisper vs vLLM backend")
+parser.add_argument("audio_path", help="Path to 16kHz mono wav file")
+parser.add_argument("--runs", type=int, default=3, help="Number of runs for averaging")
+parser.add_argument("--model", default="large-v2", help="Whisper model size for FasterWhisper")
+parser.add_argument("--lan", default="en", help="Language")
+parser.add_argument("--vllm_url", default=os.environ.get("VLLM_BASE_URL", "http://localhost:8000/v1"), help="vLLM server base URL")
+args = parser.parse_args()
+
+audio = load_audio(args.audio_path)
+
+print("Benchmarking FasterWhisper...")
+fw = FasterWhisperASR(modelsize=args.model, lan=args.lan)
+fw_times = []
+for _ in range(args.runs):
+    start = time.time()
+    fw.transcribe(audio)
+    fw_times.append(time.time() - start)
+print(f"FasterWhisper avg: {sum(fw_times)/len(fw_times):.3f}s over {args.runs} runs")
+
+print("Benchmarking vLLM backend...")
+vllm = VllmASR(lan=args.lan, base_url=args.vllm_url)
+vllm_times = []
+for _ in range(args.runs):
+    start = time.time()
+    vllm.transcribe(audio)
+    vllm_times.append(time.time() - start)
+print(f"vLLM avg: {sum(vllm_times)/len(vllm_times):.3f}s over {args.runs} runs")

--- a/whisper_online.py
+++ b/whisper_online.py
@@ -353,6 +353,20 @@ class OpenaiApiASR(ASRBase):
     def set_translate_task(self):
         self.task = "translate"
 
+class VllmASR(OpenaiApiASR):
+    """Connects to a vLLM-served Whisper model via an OpenAI compatible API."""
+
+    def __init__(self, lan=None, base_url=None, api_key=None, model="whisper", logfile=sys.stderr):
+        self.base_url = base_url or os.environ.get("VLLM_BASE_URL", "http://localhost:8000/v1")
+        self.api_key = api_key or os.environ.get("VLLM_API_KEY")
+        self.modelname = model
+        super().__init__(lan=lan, logfile=logfile)
+
+    def load_model(self, *args, **kwargs):
+        from openai import OpenAI
+        self.client = OpenAI(base_url=self.base_url, api_key=self.api_key)
+        self.transcribed_seconds = 0
+
 
 
 
@@ -771,7 +785,7 @@ def add_shared_args(parser):
     parser.add_argument('--model_dir', type=str, default=None, help="Dir where Whisper model.bin and other files are saved. This option overrides --model and --model_cache_dir parameter.")
     parser.add_argument('--lan', '--language', type=str, default='auto', help="Source language code, e.g. en,de,cs, or 'auto' for language detection.")
     parser.add_argument('--task', type=str, default='transcribe', choices=["transcribe","translate"],help="Transcribe or translate.")
-    parser.add_argument('--backend', type=str, default="faster-whisper", choices=["faster-whisper", "whisper_timestamped", "mlx-whisper", "openai-api"],help='Load only this backend for Whisper processing.')
+    parser.add_argument('--backend', type=str, default="faster-whisper", choices=["faster-whisper", "whisper_timestamped", "mlx-whisper", "openai-api", "vllm"],help='Load only this backend for Whisper processing.')
     parser.add_argument('--vac', action="store_true", default=False, help='Use VAC = voice activity controller. Recommended. Requires torch.')
     parser.add_argument('--vac-chunk-size', type=float, default=0.04, help='VAC sample size in seconds.')
     parser.add_argument('--vad', action="store_true", default=False, help='Use VAD = voice activity detection, with the default parameters.')
@@ -787,6 +801,9 @@ def asr_factory(args, logfile=sys.stderr):
     if backend == "openai-api":
         logger.debug("Using OpenAI API.")
         asr = OpenaiApiASR(lan=args.lan)
+    elif backend == "vllm":
+        logger.debug("Using vLLM server.")
+        asr = VllmASR(lan=args.lan)
     else:
         if backend == "faster-whisper":
             asr_cls = FasterWhisperASR


### PR DESCRIPTION
## Summary
- add `VllmASR` backend using an OpenAI-compatible vLLM endpoint
- allow `--backend vllm` selection
- document vLLM usage and benchmark script
- provide `benchmark_vllm_vs_fasterwhisper.py` for speed comparisons

## Testing
- `python -m py_compile whisper_online.py whisper_online_server.py silero_vad_iterator.py line_packet.py benchmark_vllm_vs_fasterwhisper.py`

------
https://chatgpt.com/codex/tasks/task_e_68403ef55a5083318762f8258709826d